### PR TITLE
Moved include strings.h statement to Non-Windows block in header file

### DIFF
--- a/header.h
+++ b/header.h
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <fcntl.h>
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -13,6 +12,7 @@
 #define strncasecmp _strnicmp
 #define LIBPATH     "C:\\Users\\Public\\Series02\\"
 #else
+#include <strings.h>
 #include <unistd.h>
 #define O_BINARY 0
 #define LIBPATH        "/usr/local/lib/"


### PR DESCRIPTION
Small change to header.h so the file can be compiled under windows.

The strings.h header file is not available in Windows, so I moved the include statement into the Non-Windows else section if the #if defined(_WIN32) || defined(_WIN64) statement in the header.h file.

With this small change, I was able to compile Link/02 under Windows.
