### PR TITLE
Fixed error in Lib directory option and added option for .sym file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ link @controlfile
 -I path       - Add path to search list for object files
 -h            - Output RCS hex
 -s            - Show public symbols
+-S            - Create .sym file for public symbols
 -o name       - Specify output filename
 -l name       - Specify library to search
 -L path       - Add path to search lift for library files

--- a/header.h
+++ b/header.h
@@ -68,5 +68,9 @@ LINK char **incPath;
 LINK int    numIncPath;
 LINK char **libPath;
 LINK int    numLibPath;
+//grw - added support for symbol map file
+LINK FILE   *symFile;
+LINK char    symName[64];
+LINK int     createSym;
 
 #endif

--- a/link.txt
+++ b/link.txt
@@ -8,6 +8,7 @@ link @controlfile
 -I path       - Add path to search list for object files
 -h            - Output RCS hex
 -s            - Show public symbols
+-S            - Create .sym file for public symbols
 -o name       - Specify output filename
 -l name       - Specify library to search
 -L path       - Add path to search lift for library files

--- a/main.c
+++ b/main.c
@@ -149,7 +149,8 @@ int loadFile(char* filename) {
           strcpy(path, libPath[i]);
           if (path[strlen(path)-1] != '/') strcat(path,"/");
           strcat(path, filename);
-          file = fopen(buffer, "r");
+          //grw - changed to open path instead of buffer
+          file = fopen(path, "r");
           if (file != NULL) i = numLibPath;
           i++;
           }
@@ -165,7 +166,8 @@ int loadFile(char* filename) {
         strcpy(path, incPath[i]);
         if (path[strlen(path)-1] != '/') strcat(path,"/");
         strcat(path, filename);
-        file = fopen(buffer, "r");
+        //grw - changed to open path instead of buffer
+        file = fopen(path, "r");
         if (file != NULL) i = numIncPath;
         i++;
         }
@@ -850,4 +852,3 @@ int main(int argc, char **argv) {
   printf("\n");
   return 0;
   }
-

--- a/main.c
+++ b/main.c
@@ -778,6 +778,10 @@ int main(int argc, char **argv) {
       printf("  Gaston Williams\n");
       exit(1);
       }
+    //grw - add option for Symbol file  
+    else if (strcmp(argv[i], "-S") == 0) {
+      createSym = -1;
+      }  
     else {
       addObject(argv[i]);
       }
@@ -796,6 +800,20 @@ int main(int argc, char **argv) {
     if (outMode == BM_INTEL) strcat(outName, ".intel");
     if (outMode == BM_RCS) strcat(outName, ".hex");
     }
+  //grw - create symbol file name from outName
+  if (createSym) {
+    //grw - symName is up to 64 characters including ".sym"
+    if (strlen(outName) > 60) {
+      strncpy(symName, outName, 60);
+      symName[60] = 0;
+    } else 
+      strcpy(symName, outName);
+    
+    for (i = 0; i < strlen(symName); i++)
+      if (symName[i] == '.')
+        symName[i] = 0;
+    strcat(symName, ".sym");    
+  }  
   for (i=0; i<65536; i++) {
     memory[i] = 0;
     map[i] = 0;
@@ -844,11 +862,23 @@ int main(int argc, char **argv) {
   printf("Public symbols : %d\n",numSymbols);
   if (startAddress != 0xffff)
     printf("Start address  : %04x\n",startAddress);
+
   if (showSymbols) {
     sortSymbols();
     for (i=0; i<numSymbols; i++)
       printf("%-20s %04x\n",symbols[i], values[i]);
-    }
+  }
+    
+  if (createSym) {
+    symFile = fopen(symName, "w");
+    if (symFile != NULL) {
+    sortSymbols();
+    for (i=0; i<numSymbols; i++)
+      fprintf(symFile, "%-20s %04x\n",symbols[i], values[i]);
+    fclose(symFile);
+    } else 
+      printf("Error opening symbol map file %s.\n", symName);
+  }
   printf("\n");
   return 0;
   }


### PR DESCRIPTION
Two sets of updates in this release.  The first one fixes a small issue where if one specifies a directory to search for libraries that option did not function correctly. 

The second set of changes adds a -S option so that the linker will create a .sym file with all the public symbol information.  This allows the symbol mapping to be saved to a file.

Please let me know if you have any questions.